### PR TITLE
Fix example in README.md to ease the bootstrap of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ ruleset(name="process_stats") {
   action(
     type="omprog"
     name="to_exporter"
-    binary="/usr/local/bin/rsyslog_exporter"
+    binary="/usr/local/bin/rsyslog_exporter "
   )
 }
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ module(
   ruleset="process_stats"
 )
 
+module(load="omprog")
+
 ruleset(name="process_stats") {
   action(
     type="omprog"


### PR DESCRIPTION
# Description of the issue

I had 2 problems related to the configuration example. The first is simple the `omprog` module is not loaded in the example. 

The second problem may be related to the version of rsyslog. I reproduced the same error on a centos7 (vmware box) and a debian9 (docker version). Please find version detail below. 

This error seems to be related to the way of the binary is loaded by `rsyslog` that generates a panic.


```
panic: runtime error: index out of range

goroutine 1 [running]:
panic(0x771b00, 0xc420014070)
/usr/lib/go-1.7/src/runtime/panic.go:500 +0x1a1
flag.init()
/usr/lib/go-1.7/src/flag/flag.go:954 +0x111
main.init()
/root/go/src/github.com/soundcloud/rsyslog_exporter/utils.go:20 +0x71
rsyslogd: Child 6440 has terminated, reaped by main-loop. [v8.24.0 try http://www.rsyslog.com/e/0 ]
```


## Version of rsyslog

Centos7:
```bash
07/02 09:47:16 /etc/rsyslog.d# rsyslogd -v 
rsyslogd 8.24.0-34.el7, compiled with:
        PLATFORM:                               x86_64-redhat-linux-gnu
        PLATFORM (lsb_release -d):
        FEATURE_REGEXP:                         Yes
        GSSAPI Kerberos 5 support:              Yes
        FEATURE_DEBUG (debug build, slow code): No
        32bit Atomic operations supported:      Yes
        64bit Atomic operations supported:      Yes
        memory allocator:                       system default
        Runtime Instrumentation (slow code):    No
        uuid support:                           Yes
        Number of Bits in RainerScript integers: 64
``` 

Debian9:
```bash
root@e8d246e8170a:/etc/rsyslog.d# rsyslogd -v
rsyslogd 8.24.0, compiled with:
	PLATFORM:				x86_64-pc-linux-gnu
	PLATFORM (lsb_release -d):		
	FEATURE_REGEXP:				Yes
	GSSAPI Kerberos 5 support:		Yes
	FEATURE_DEBUG (debug build, slow code):	No
	32bit Atomic operations supported:	Yes
	64bit Atomic operations supported:	Yes
	memory allocator:			system default
	Runtime Instrumentation (slow code):	No
	uuid support:				Yes
	Number of Bits in RainerScript integers: 64
```

## Reproduce the errors

The following commands allows to reproduce the error in a debian container:
```bash
# This command is executed on the host 

sudo docker run --rm -it debian:latest bash

# The following commands are executed in the docker container

apt update && apt install -y git rsyslog golang
export GOPATH=/root/go
go get -v github.com/soundcloud/rsyslog_exporter
cat > /etc/rsyslog.d/prom_exporter.conf<<EOF
module(
  load="impstats"
  interval="10"
  format="json"
  resetCounters="off"
  ruleset="process_stats"
)

module(load="omprog")

ruleset(name="process_stats") {
  action(
    type="omprog"
    name="to_exporter"
    binary="/root/go/bin/rsyslog_exporter"
  )
}
EOF
export RSYSLOG_DEBUG=DebugOnDemand
rsyslogd -n

```
Wait approximativery 10s to have the error printed in your container.